### PR TITLE
(feat) Add support for kubernetes service account tokens in routes.

### DIFF
--- a/docs/resources/route.md
+++ b/docs/resources/route.md
@@ -72,6 +72,7 @@ resource "pomeriumzero_route" "foobar_tooling" {
 - `show_error_details` (Boolean) If set to `true`, shows detailed error messages when errors occur.
 - `tls_skip_verify` (Boolean) If set to `true`, skips TLS verification for upstream connections. Use with caution.
 - `tls_upstream_allow_renegotiation` (Boolean) If set to `true`, allows TLS renegotiation for upstream connections.
+- `kubernetes_service_account_token` (String) Kubernetes service account token used for accessing kubernetes api via pomerium.
 
 ### Read-Only
 

--- a/examples/resources/pomeriumzero_route/resource.tf
+++ b/examples/resources/pomeriumzero_route/resource.tf
@@ -32,3 +32,17 @@ resource "pomeriumzero_route" "foobar_tooling" {
     pomeriumzero_policy.allow_foobar_group_members.id
   ]
 }
+
+resource "pomeriumzero_route" "kubernetes_api" {
+  name = "Kubernetes API"
+  from = "https://k8s-api.${pomeriumzero_cluster.default.fqdn}"
+  to = ["https://kubernetes.default.svc.cluster.local/"]
+  namespace_id = data.pomeriumzero_cluster.default.namespace_id
+  allow_websockets = false
+  preserve_host_header = false
+  policy_ids = [
+    pomeriumzero_policy.allow_kubernetes_admins.id
+  ]
+  pass_identity_headers = true
+  kubernetes_service_account_token = data.kubernetes_secret.k8s_api_service_account_token.data["token"]
+}

--- a/internal/provider/route_resource.go
+++ b/internal/provider/route_resource.go
@@ -54,6 +54,7 @@ type RouteResourceModel struct {
 	PolicyIDs                                 types.List   `tfsdk:"policy_ids"`
 	Prefix                                    types.String `tfsdk:"prefix"`
 	PrefixRewrite                             types.String `tfsdk:"prefix_rewrite"`
+	KubernetesServiceAccountToken             types.String `tfsdk:"kubernetes_service_account_token"`
 }
 
 // Metadata sets the resource type name for the RouteResource.
@@ -170,6 +171,12 @@ func (r *RouteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"prefix_rewrite": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "If specified, rewrites the URL prefix before forwarding the request to the upstream service.",
+			},
+			// Kubernetes service account token, optional field
+			"kubernetes_service_account_token": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "The Kubernetes service account token to use for authentication.",
+				Sensitive:           true,
 			},
 		},
 	}
@@ -525,6 +532,7 @@ func createRouteRequest(model *RouteResourceModel) map[string]interface{} {
 		"showErrorDetails":                          model.ShowErrorDetails.ValueBool(),
 		"tlsSkipVerify":                             model.TLSSkipVerify.ValueBool(),
 		"tlsUpstreamAllowRenegotiation":             model.TLSUpstreamAllowRenegotiation.ValueBool(),
+		"kubernetesServiceAccountToken":             model.KubernetesServiceAccountToken.ValueString(),
 	}
 
 	// Add 'to' field if it's not null
@@ -558,6 +566,9 @@ func createRouteRequest(model *RouteResourceModel) map[string]interface{} {
 	}
 	if !model.PrefixRewrite.IsNull() {
 		req["prefixRewrite"] = model.PrefixRewrite.ValueString()
+	}
+	if !model.KubernetesServiceAccountToken.IsNull() {
+		req["kubernetesServiceAccountToken"] = model.KubernetesServiceAccountToken.ValueString()
 	}
 
 	// Return the constructed request map
@@ -619,6 +630,9 @@ func mapRouteResponseToModel(ctx context.Context, apiResponse map[string]interfa
 	}
 	if prefixRewrite, ok := apiResponse["prefixRewrite"].(string); ok {
 		model.PrefixRewrite = types.StringValue(prefixRewrite)
+	}
+	if kubernetesServiceAccountToken, ok := apiResponse["kubernetesServiceAccountToken"].(string); ok {
+		model.KubernetesServiceAccountToken = types.StringValue(kubernetesServiceAccountToken)
 	}
 
 	// Return the populated model


### PR DESCRIPTION
This adds support for the kubernetes service account token that's defined [here](kubernetes_service_account_token)