### PR TITLE
(fix) set k8s sa token to computed + add plan modifier to handle null case

### DIFF
--- a/internal/provider/route_resource.go
+++ b/internal/provider/route_resource.go
@@ -175,8 +175,12 @@ func (r *RouteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			// Kubernetes service account token, optional field
 			"kubernetes_service_account_token": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				MarkdownDescription: "The Kubernetes service account token to use for authentication.",
 				Sensitive:           true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes issue:

```
| Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to pomeriumzero_route.verify, provider "provider[\"registry.terraform.io/rasschaert/pomeriumzero\"]"
│ produced an unexpected new value: .kubernetes_service_account_token: inconsistent values for sensitive attribute.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.